### PR TITLE
Add loading spinner and 5s delay for home data

### DIFF
--- a/src/mocks/home.ts
+++ b/src/mocks/home.ts
@@ -36,4 +36,7 @@ const mockHomeData: HomeData = {
   history: [],
 };
 
-export const fetchHomeData = async (): Promise<HomeData> => mockHomeData;
+export const fetchHomeData = async (): Promise<HomeData> =>
+  new Promise((resolve) => {
+    setTimeout(() => resolve(mockHomeData), 5000);
+  });

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,20 +1,26 @@
 // src/pages/Home.tsx
-import { Box, Heading, VStack } from "@chakra-ui/react";
+import { Box, Heading, VStack, Spinner, Center } from "@chakra-ui/react";
 import { Layout } from "../components/Layout";
 import CardGroup from "@/components/CardGroup";
 import { useEffect, useState } from "react";
 import { fetchHomeData, type HomeData } from "@/mocks/home";
 
 export const Home = () => {
-  const [data, setData] = useState<HomeData>({
-    notify: [],
-    open: [],
-    history: [],
-  });
+  const [data, setData] = useState<HomeData | null>(null);
 
   useEffect(() => {
     fetchHomeData().then(setData);
   }, []);
+
+  if (!data) {
+    return (
+      <Layout>
+        <Center py={10}>
+          <Spinner size="xl" />
+        </Center>
+      </Layout>
+    );
+  }
 
   return (
     <Layout>


### PR DESCRIPTION
## Summary
- delay mock `fetchHomeData` by 5 seconds
- show a Chakra UI spinner while data loads

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6880651461c883248b15b55c861554ca