### PR TITLE
Split home data fetching

### DIFF
--- a/src/mocks/home.ts
+++ b/src/mocks/home.ts
@@ -1,19 +1,14 @@
 import type { CardData } from "@/components/CardGroup";
 
-export type HomeData = {
-  notify: CardData[];
-  open: CardData[];
-  history: CardData[];
-};
-
-const mockHomeData: HomeData = {
-  notify: [
+// モックデータ
+const notifyData: CardData[] = [
     {
       title: "メンテナンスのお知らせ",
       description: "7/25 22:00〜システム停止します",
     },
-  ],
-  open: [
+];
+
+const openData: CardData[] = [
     { title: "React研修", description: "8/1 開始予定。基本から学べます" },
     { title: "Kubernetes入門", description: "応募受付中！" },
     { title: "Dockerハンズオン", description: "コンテナ基礎を学ぼう" },
@@ -32,11 +27,21 @@ const mockHomeData: HomeData = {
       title: "マイクロサービス設計",
       description: "分割統治のベストプラクティス",
     },
-  ],
-  history: [],
-};
+];
 
-export const fetchHomeData = async (): Promise<HomeData> =>
+const historyData: CardData[] = [];
+
+export const fetchNotifyData = async (): Promise<CardData[]> =>
   new Promise((resolve) => {
-    setTimeout(() => resolve(mockHomeData), 5000);
+    setTimeout(() => resolve(notifyData), 500);
+  });
+
+export const fetchOpenData = async (): Promise<CardData[]> =>
+  new Promise((resolve) => {
+    setTimeout(() => resolve(openData), 500);
+  });
+
+export const fetchHistoryData = async (): Promise<CardData[]> =>
+  new Promise((resolve) => {
+    setTimeout(() => resolve(historyData), 500);
   });

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -2,17 +2,26 @@
 import { Box, Heading, VStack, Spinner, Center } from "@chakra-ui/react";
 import { Layout } from "../components/Layout";
 import CardGroup from "@/components/CardGroup";
+import type { CardData } from "@/components/CardGroup";
 import { useEffect, useState } from "react";
-import { fetchHomeData, type HomeData } from "@/mocks/home";
+import {
+  fetchNotifyData,
+  fetchOpenData,
+  fetchHistoryData,
+} from "@/mocks/home";
 
 export const Home = () => {
-  const [data, setData] = useState<HomeData | null>(null);
+  const [notify, setNotify] = useState<CardData[] | null>(null);
+  const [open, setOpen] = useState<CardData[] | null>(null);
+  const [history, setHistory] = useState<CardData[] | null>(null);
 
   useEffect(() => {
-    fetchHomeData().then(setData);
+    fetchNotifyData().then(setNotify);
+    fetchOpenData().then(setOpen);
+    fetchHistoryData().then(setHistory);
   }, []);
 
-  if (!data) {
+  if (!notify || !open || !history) {
     return (
       <Layout>
         <Center py={10}>
@@ -30,7 +39,7 @@ export const Home = () => {
         <Heading as="h2" size="lg" mb={4}>
           お知らせ
         </Heading>
-        <CardGroup items={data.notify} />
+        <CardGroup items={notify} />
       </Box>
 
       {/* 募集中 */}
@@ -38,7 +47,7 @@ export const Home = () => {
         <Heading as="h2" size="lg" mb={4}>
           募集中
         </Heading>
-        <CardGroup items={data.open} />
+        <CardGroup items={open} />
       </Box>
 
       {/* 受講済 */}
@@ -46,7 +55,7 @@ export const Home = () => {
         <Heading as="h2" size="lg" mb={4}>
           受講済
         </Heading>
-        <CardGroup items={data.history} />
+        <CardGroup items={history} />
       </Box>
     </VStack>
   </Layout>


### PR DESCRIPTION
## Summary
- split mocked API into three fetch functions for each data set
- update Home page to load each list separately

## Testing
- `yarn lint` *(fails: package not present in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_688066ae6ec48324a8229d861fff09b9